### PR TITLE
Fix use of Visual Studio compiler values "-w..." or "-FS"

### DIFF
--- a/gas-preprocessor.pl
+++ b/gas-preprocessor.pl
@@ -163,6 +163,8 @@ if ($as_type ne "armasm") {
     @preprocess_c_cmd = grep ! /^-EHsc$/, @preprocess_c_cmd;
     @preprocess_c_cmd = grep ! /^-O/, @preprocess_c_cmd;
     @preprocess_c_cmd = grep ! /^-oldit/, @preprocess_c_cmd;
+    @preprocess_c_cmd = grep ! /^-FS/, @preprocess_c_cmd;
+    @preprocess_c_cmd = grep ! /^-w/, @preprocess_c_cmd;
 
     @gcc_cmd = grep ! /^-G/, @gcc_cmd;
     @gcc_cmd = grep ! /^-W/, @gcc_cmd;
@@ -170,6 +172,8 @@ if ($as_type ne "armasm") {
     @gcc_cmd = grep ! /^-fp/, @gcc_cmd;
     @gcc_cmd = grep ! /^-EHsc$/, @gcc_cmd;
     @gcc_cmd = grep ! /^-O/, @gcc_cmd;
+    @gcc_cmd = grep ! /^-FS/, @gcc_cmd;
+    @gcc_cmd = grep ! /^-w/, @gcc_cmd;
 
     my @outfiles = grep /\.(o|obj)$/, @gcc_cmd;
     $tempfile = $outfiles[0].".asm";


### PR DESCRIPTION
This was needed by a Kodi addon project and ffmpeg Windows ARM compile,
where the flag "-FS" was needed, to become AppVeyor and Jenkins
more happy and the "-w..." to prevent one warning, which was given by
config.h on every compile file.

Without comes on configure:
```bash
BEGIN ./ffconf.KEHnLLrW/test.S
    1
    2   .macro m n, y:vararg=0
    3   \n: .int \y
    4   .endm
    5   m x
END ./ffconf.KEHnLLrW/test.S
gas-preprocessor.pl -arch aarch64 -as-type armasm -- armasm64.exe -I/d/Dev/Kodi64/NEW/inputstream.ffmpegdirect/build2/build/depends/include -D_ISOC99_SOURCE -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -D_USE_MATH_DEFINES -D_CRT_SECURE_NO_WARNINGS -D_CRT_NONSTDC_NO_WARNINGS -nologo -ignore 4509 -DWIN32 -D_WINDOWS -W3 -DUNICODE -D_UNICODE -DTARGET_WINDOWS -DTARGET_WINDOWS_STORE -DNOMINMAX -D_CRT_SECURE_NO_WARNINGS -D_WINSOCKAPI_ -ID:/Dev/Kodi64/NEW/inputstream.ffmpegdirect/build2/build/depends/include -ID:/Dev/Kodi64/NEW/inputstream.ffmpegdirect/build2/build/depends/include/libxml2 -FS -DWINAPI_FAMILY=WINAPI_FAMILY_APP -D_WIN32_WINNT=0x0A00 -wd4828 -mcpu=aarch64 -c -o ./ffconf.KEHnLLrW/test.o ./ffconf.KEHnLLrW/test.S
cpp.exe: error: unrecognized command line option '-wd4828'
GNU assembler not found, install/update gas-preprocessor
```

I'm not sure if OK, just thought that if I bring a patch into the project (https://github.com/AlwinEsch/inputstream.ffmpegdirect/tree/build-fixes/depends/common/gas-preprocessor), I could also ask and try to bring it in directly.
